### PR TITLE
Fix notification #46

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,13 +1,3 @@
 class ApplicationController < ActionController::Base
   add_flash_types :success, :info, :warning, :danger
-
-  before_action :basic
-
-  def basic
-    return unless Rails.env == 'production'
-
-    authenticate_or_request_with_http_basic do |name, password|
-      name == ENV['BASIC_AUTH_NAME'] && password == ENV['BASIC_AUTH_PASSWORD']
-    end
-  end
 end

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -1,8 +1,13 @@
 class NotificationsController < ApplicationController
   def create
     event = Event.find(params[:event_id])
-    current_user.notification(event)
-    redirect_back fallback_location: root_path
+    if event.ended_at > Time.current
+      current_user.notification(event)
+      redirect_back fallback_location: root_path
+    else
+      flash[:info] = "イベントが終了しています"
+      redirect_back fallback_location: root_path
+    end
   end
 
   def destroy

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -3,11 +3,10 @@ class NotificationsController < ApplicationController
     event = Event.find(params[:event_id])
     if event.ended_at > Time.current
       current_user.notification(event)
-      redirect_back fallback_location: root_path
     else
-      flash[:alert] = "イベントが終了しています"
-      redirect_back fallback_location: root_path
+      flash[:alert] = 'イベントが終了しています'
     end
+    redirect_back fallback_location: root_path
   end
 
   def destroy

--- a/app/controllers/notifications_controller.rb
+++ b/app/controllers/notifications_controller.rb
@@ -5,7 +5,7 @@ class NotificationsController < ApplicationController
       current_user.notification(event)
       redirect_back fallback_location: root_path
     else
-      flash[:info] = "イベントが終了しています"
+      flash[:alert] = "イベントが終了しています"
       redirect_back fallback_location: root_path
     end
   end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,0 +1,8 @@
+class UserSessionsController < ApplicationController
+  def new; end
+  
+  def destroy
+    logout
+    redirect_to root_path
+  end
+end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -1,6 +1,6 @@
 class UserSessionsController < ApplicationController
   def new; end
-  
+
   def destroy
     logout
     redirect_to root_path

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,3 +1,9 @@
 @import "tailwindcss/base";
 @import "tailwindcss/components";
 @import "tailwindcss/utilities";
+.message-notice {
+  @apply bg-green-100 border-t-4 border-green-500 rounded-b text-green-900 px-4 py-3 mt-32 -mb-24 shadow-md ;
+}
+.message-alert {
+  @apply bg-red-100 border-t-4 border-red-500 rounded-b text-red-900 px-4 py-3 mt-32 -mb-24 shadow-md ;
+}

--- a/app/views/events/notifications.html.erb
+++ b/app/views/events/notifications.html.erb
@@ -1,7 +1,9 @@
 <% set_meta_tags title: 'イベント通知一覧' %>
 <div class="container mx-auto mt-32">
   <section class="mx-5 mb-10">
-    <% if @notification_events.present? %>
+    <% if !logged_in? %>
+      <p>LINEログインしてイベント通知を確認してね！</p>
+    <% elsif @notification_events.present? %>
       <%= render @notification_events %>
     <% else %>
       <p>通知登録しているイベントがまだないよ！</p>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -26,13 +26,13 @@
           <div class="text-left py-2 text-2xl font-semibold">LINE通知</div>
           <div class="text-base py-2 font-semibold ">
             <div class="flex flex-wrap text-xl ">
-              <% if current_user == nil %>
+              <% if logged_in? %>
+                <%= render 'notification_button', event: @event  %>
+              <% else %>
                 <p class="my-auto">LINEログインしてイベント通知を受け取ろう！</p>
                 <%= link_to auth_at_provider_path(provider: :line) do %>
                   <%= image_tag 'line_login.png', size: '150x40', class: "line-login" %>
                 <% end %>
-              <% else %>
-                <%= render 'notification_button', event: @event  %>
               <% end %>
             </div>
           </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -12,6 +12,7 @@
 
   <body class="flex flex-col min-h-screen text-gray-600 bg-gray-50">
     <%= render 'shared/header'%>
+    <%= render 'shared/flash_message' %>
     <main class="flex-grow">
       <%= yield %>
     </main>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,3 +1,3 @@
 <% flash.each do |message_type, message| %>
-  <div class="alert alert-<%= message_type %>"><%= message %></div>
+  <div class="py-2 px-4 font-bold message-<%= message_type %>"><%= message %></div>
 <% end %>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -15,6 +15,17 @@
         <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="ai ai-Bell"><path d="M12.721 5.003L11.255 5c-3.344-.008-6.247 2.709-6.27 6v3.79c0 .79-.1 1.561-.531 2.218l-.287.438C3.73 18.11 4.2 19 4.985 19h14.03c.785 0 1.254-.89.818-1.554l-.287-.438c-.43-.657-.531-1.429-.531-2.219v-3.788c-.04-3.292-2.95-5.99-6.294-5.998z"/><path d="M15 19a3 3 0 1 1-6 0"/><path d="M12 2a2 2 0 0 1 2 2v1h-4V4a2 2 0 0 1 2-2z"/></svg>
         <span class="mr-5 ml-2 text-sm md:text-xl hover:text-blue-300">イベント通知一覧</span>
       <% end %>
+      <% if logged_in? %>
+        <%= link_to(logout_path, method: :delete, class: "flex flex-wrap items-center text-base justify-center") do %>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path fill="none" d="M0 0h24v24H0z"/><path d="M4 18h2v2h12V4H6v2H4V3a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-3zm2-7h7v2H6v3l-5-4 5-4v3z" fill="rgba(255,255,255,1)"/></svg>
+          <span class="mr-5 ml-2 text-sm md:text-xl hover:text-blue-300">ログアウト</span>
+        <% end %>
+      <% else %>
+        <%= link_to(login_path, class: "flex flex-wrap items-center text-base justify-center") do %>
+          <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" width="24" height="24"><path fill="none" d="M0 0h24v24H0z"/><path d="M4 15h2v5h12V4H6v5H4V3a1 1 0 0 1 1-1h14a1 1 0 0 1 1 1v18a1 1 0 0 1-1 1H5a1 1 0 0 1-1-1v-6zm6-4V8l5 4-5 4v-3H2v-2h8z" fill="rgba(255,255,255,1)"/></svg>
+          <span class="mr-5 ml-2 text-sm md:text-xl hover:text-blue-300">ログイン</span>
+        <% end %>
+      <% end %>
     </div>
   </div>
 </nav>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,0 +1,9 @@
+<% set_meta_tags title: 'ログイン' %>
+<div class="container mx-auto mt-32">
+  <div class='bg-white m-10 p-10 rounded-lg'>
+    <p class="my-auto">LINEログインするとイベント通知を受け取ることができるよ！</p>
+    <%= link_to auth_at_provider_path(provider: :line) do %>
+      <%= image_tag 'line_login.png', size: '150x40', class: "line-login" %>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
   post 'oauth/callback', to: 'oauths#callback'
   get 'oauth/callback', to: 'oauths#callback'
   get 'oauth/:provider', to: 'oauths#oauth', as: :auth_at_provider
+  get 'login', to: 'user_sessions#new'
+  delete 'logout', to: 'user_sessions#destroy'
   resources :events, only: %i[index show] do
     collection do
       get :notifications

--- a/lib/tasks/event_scraping.rake
+++ b/lib/tasks/event_scraping.rake
@@ -93,6 +93,6 @@ end
 namespace :notification_destroy do
   desc 'イベントが終了していたら通知から削除'
   task event_notification_destroy: :environment do
-    Notification.joins(:event).where('ended_at <= ?', Time.current ).delete_all
+    Notification.joins(:event).where('ended_at <= ?', Time.current).delete_all
   end
 end

--- a/lib/tasks/event_scraping.rake
+++ b/lib/tasks/event_scraping.rake
@@ -89,3 +89,10 @@ namespace :event_notification do
     end
   end
 end
+
+namespace :notification_destroy do
+  desc 'イベントが終了していたら通知から削除'
+  task event_notification_destroy: :environment do
+    Notification.joins(:event).where('ended_at <= ?', Time.current ).delete_all
+  end
+end


### PR DESCRIPTION
- イベント終了していたら通知から削除するタスクを追加
- フラッシュメッセージの追加
- basic認証の解除
- LINEログイン・ログアウトをヘッダーに追加
-  イベントが終わっていたら通知に追加できないように設定